### PR TITLE
Increase mac_ebs_volume_size from 60 to 100

### DIFF
--- a/terraform-aws-ec2-mac/variables.tf
+++ b/terraform-aws-ec2-mac/variables.tf
@@ -118,7 +118,7 @@ variable "security_group_ids" {
 variable "mac_ebs_volume_size" {
   description = "EC2 Mac1 EBS volume size"
   type        = number
-  default     = 60
+  default     = 100
 }
 
 variable "worker_prefix" {


### PR DESCRIPTION
It seems the latest mac image needs more space.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
